### PR TITLE
Fixes on init data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ARCH ?= x86_64
 export ARCH
 
 # Set this variable to the path of SEPC2006 to run the `init` rule for the first time
-SPEC =
+SPEC ?=
 
 ifeq ($(SPEC),)
 init:

--- a/Makefile.apps
+++ b/Makefile.apps
@@ -7,7 +7,7 @@ html:
 
 ## 1. Basic Setup and Checks
 
-SPEC=
+SPEC ?=
 ### Default to create a bare-metal kernel image
 ifeq ($(MAKECMDGOALS),)
   MAKECMDGOALS  = $(APP)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ export ARCH=riscv64
 export CROSS_COMPILE=riscv64-unknown-linux-gnu-
 make build-all -j 70
 ```
+- init data
+```
+make init
+```
 - collect result
 ```
 bash scripts/collect.sh

--- a/README.md
+++ b/README.md
@@ -8,12 +8,6 @@ The compatibility flags and including paths are set in each Makefile of benchmar
 
 # How to
 
-- set SPEC2006 path in Makefile.app
-``` Makefile
-# update SPEC variable to your SPEC2006 path in Makefile.app
-SPEC=/spec2006_path
-
-```
 - set SPEC2006 path in env vars
 
 ``` shell


### PR DESCRIPTION
This PR fixes the README.md to tell users to init data from SPEC CPU dir, and then replace `=` with `?=` for the `SPEC` variable in Makefile so we don't need to modify the Makefile, only set `SPEC` in env will get it works.