### PR TITLE
add support: use qemu to run riscv binary, to difftest with reference…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ validate-fp-$(1):
 	for t in $$(SPECFP); do $$(MAKE) -s -C $$$$t $(1)-cmp; done
 
 run-%-$(1):
+	echo "Running $(1) on $$*"
 	@$$(MAKE) -s -C $$* run-$(1) > $$*/build/run-$(1).log
 
 report-int-$(1):

--- a/Makefile.apps
+++ b/Makefile.apps
@@ -153,7 +153,7 @@ SPECDIFF = cd $(dir $(SPECDIFF_FILE)) && ./specdiff -m -l 10 $(1) $(abspath $(2)
 # prototype: cmd_template(size)
 define cmd_template
 run-$(1): $$(APP)
-	@sh $(SPEC_LITE)/scripts/run-template.sh $(NAME)/run-$(1).sh
+	@sh $(SPEC_LITE)/scripts/run-template.sh run-$(1).sh
 	@echo ============ Checking $(notdir $$<) ============
 	@$(MAKE) -s $(1)-cmp
 	@echo ""

--- a/README.md
+++ b/README.md
@@ -76,6 +76,24 @@ make ARCH=riscv64 \
      build-all -j 29
 ```
 
+# Run with QEMU to difftest
+
+use qemu-riscv64 to run the riscv compiled binarys, 
+compare the output with speccpu reference output,
+you can check the correctness of the compiled binarys.
+
+use nix to install qemu or 
+sudo apt install qemu-user-static
+qemu version should be >= 8.2, support riscv64 zba extension
+
+```shell
+export ARCH=riscv64
+make run-int-test   // use specint test input, qemu runs about 3mins
+make run-fp-test    // use specfp test input, qemu runs about 15mins
+```
+
+if no error occurs, the compiled binarys are correct.
+
 # Note for GCC >= 14
 
 The old version of xerces-c in 483.xalancbmk [contains a bug](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111544) that will cause compile errors in GCC 14 and later. You may need to apply the following patch to SPEC CPU 2006 source code to get this fixed:

--- a/README.md
+++ b/README.md
@@ -83,16 +83,38 @@ compare the output with speccpu reference output,
 you can check the correctness of the compiled binarys.
 
 use nix to install qemu or 
-sudo apt install qemu-user-static
-qemu version should be >= 8.2, support riscv64 zba extension
+sudo apt install qemu-user-static.
+```
+nix-env -iA nixpkgs.qemu 
+sudo apt install qemu-user-static  // ubuntu
+```
+
+qemu version should support riscv64 Bit extension
 
 ```shell
 export ARCH=riscv64
+make ARCH=riscv64 \
+     CROSS_COMPILE=riscv64-unknown-linux-gnu- \
+     OPTIMIZE="-O3 -flto" \
+     SUBPROCESS_NUM=5 \
+     build-all -j 29     // compile riscv version
 make run-int-test   // use specint test input, qemu runs about 3mins
 make run-fp-test    // use specfp test input, qemu runs about 15mins
 ```
 
 if no error occurs, the compiled binarys are correct.
+
+you can also compile x86 version and run the x86 compiled binarys native on your machine.
+
+```shell
+export ARCH=x86
+make ARCH=x86 \
+     OPTIMIZE="-O3 -flto" \
+     SUBPROCESS_BUM=5 \
+     build-all -j 29     // compile x86 version
+make run-int-test   // use specint test input
+make run-fp-test    // use specfp test input
+```
 
 # Note for GCC >= 14
 

--- a/scripts/run-template.sh
+++ b/scripts/run-template.sh
@@ -20,5 +20,15 @@ TIME_LOG=$WORK_DIR/run/`basename $1`.timelog
 export TIME='%Uuser %Ssystem %Eelapsed %PCPU (%Xtext+%Ddata %Mmax)k\n%Iinputs+%Ooutputs (%Fmajor+%Rminor)pagefaults %Wswaps\n%e # elapsed in second'
 date | tee $TIME_LOG
 echo "@@@@@ Running $FULLNAME [$SIZE]..." | tee -a $TIME_LOG
-APP="/usr/bin/time -a -o $TIME_LOG $LOADER $WORK_DIR/build/$NAME" sh $RUN_SH
+
+# 检查环境变量，如果  ARCH == riscv64，那么使用 qemu-riscv64
+case "${ARCH:-}" in
+  riscv64)
+    LOADER="qemu-riscv64"
+    ;;
+  *)
+    LOADER=""
+    ;;
+esac
+APP="/usr/bin/time -a -o $TIME_LOG $LOADER $WORK_DIR/build/$FULLNAME" sh $RUN_SH
 cat $TIME_LOG


### PR DESCRIPTION
use qemu-riscv64 to run the riscv compiled binarys, 
compare the output with speccpu reference output,
you can check the correctness of the compiled binarys.