### PR TITLE
Fixed bugs in README, 403.gcc, 540.soplex

### DIFF
--- a/403.gcc/run-ref.sh
+++ b/403.gcc/run-ref.sh
@@ -1,3 +1,4 @@
 for f in 166 200 c-typeck cp-decl expr expr2 g23 s04 scilab; do
-  $APP $f.i -o $f.s
+  INPUT=$(find . -maxdepth 1 -type f -name "$f.i*" -printf "%f\n" | head -n 1)
+  $APP "$INPUT" -o $f.s
 done

--- a/403.gcc/run-test.sh
+++ b/403.gcc/run-test.sh
@@ -1,1 +1,3 @@
-$APP cccp.i -o cccp.s
+INPUT=$(find . -maxdepth 1 -type f -name "cccp.i*" -printf "%f\n" | head -n 1)
+
+$APP "$INPUT" -o cccp.s

--- a/403.gcc/run-train.sh
+++ b/403.gcc/run-train.sh
@@ -1,1 +1,3 @@
-$APP integrate.i -o integrate.s
+INPUT=$(find . -maxdepth 1 -type f -name "integrate.i*" -printf "%f\n" | head -n 1)
+
+$APP "$INPUT" -o integrate.s

--- a/450.soplex/Makefile
+++ b/450.soplex/Makefile
@@ -15,19 +15,32 @@ CFLAGS += -std=c++03
 LD_CXX = 1
 include ../Makefile.apps
 
+# Add this function to accommodate different versions of spec06 file suffixes
+adapt_suffix = $(shell if test -f $(1)$(2); then echo $(1)$(2); elif test -f $(1)$(3); then echo $(1)$(3); fi)
+
 test-cmp:
 	$(call SPECDIFF, --abstol 1e-05  --reltol 0.0001 --obiwan, run/test.out, data/test/output/test.out)
-	$(call SPECDIFF, --abstol 20  --reltol 10 --obiwan, run/test.stderr, data/test/output/test.stderr)
+	$(call SPECDIFF, --abstol 20  --reltol 10 --obiwan, \
+		$(call adapt_suffix,run/test,.mps.info,.stderr), \
+		$(call adapt_suffix,data/test/output/test,.mps.info,.stderr))
 
 train-cmp:
 	$(call SPECDIFF, --abstol 1e-05  --reltol 20 --obiwan, run/pds-20.mps.out, data/train/output/pds-20.mps.out)
-	$(call SPECDIFF, --abstol 20  --reltol 0.0001 --obiwan, run/pds-20.mps.stderr, data/train/output/pds-20.mps.stderr)
+	$(call SPECDIFF, --abstol 20  --reltol 0.0001 --obiwan, \
+		$(call adapt_suffix,run/pds-20,.mps.info,.stderr), \
+		$(call adapt_suffix,data/train/output/pds-20,.mps.info,.stderr))
 	$(call SPECDIFF, --abstol 1e-05  --reltol 20 --obiwan, run/train.out, data/train/output/train.out)
-	$(call SPECDIFF, --abstol 20  --reltol 0.0001 --obiwan, run/train.stderr, data/train/output/train.stderr)
+	$(call SPECDIFF, --abstol 20  --reltol 0.0001 --obiwan, \
+		$(call adapt_suffix,run/train,.mps.info,.stderr), \
+		$(call adapt_suffix,data/train/output/train,.mps.info,.stderr))
 
 ref-cmp:
 	$(call SPECDIFF, --abstol 1e-05  --reltol 0.02 --obiwan, run/pds-50.mps.out, data/ref/output/pds-50.mps.out)
-	$(call SPECDIFF, --abstol 20  --reltol 0.0001 --obiwan, run/pds-50.mps.stderr, data/ref/output/pds-50.mps.stderr)
+	$(call SPECDIFF, --abstol 20  --reltol 0.0001 --obiwan, \
+		$(call adapt_suffix,run/pds-50,.mps.info,.stderr), \
+		$(call adapt_suffix,data/ref/output/pds-50,.mps.info,.stderr))
 	$(call SPECDIFF, --abstol 1e-05  --reltol 0.02 --obiwan, run/ref.out, data/ref/output/ref.out)
-	$(call SPECDIFF, --abstol 20  --reltol 0.0001 --obiwan, run/ref.stderr, data/ref/output/ref.stderr)
+	$(call SPECDIFF, --abstol 20  --reltol 0.0001 --obiwan, \
+		$(call adapt_suffix,run/ref,.mps.info,.stderr), \
+		$(call adapt_suffix,data/ref/output/ref,.mps.info,.stderr))
 include Makefile.deps

--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ if no error occurs, the compiled binarys are correct.
 you can also compile x86 version and run the x86 compiled binarys native on your machine.
 
 ```shell
-export ARCH=x86
-make ARCH=x86 \
+export ARCH=x86_64
+make ARCH=x86_64 \
      OPTIMIZE="-O3 -flto" \
      SUBPROCESS_BUM=5 \
      build-all -j 29     // compile x86 version


### PR DESCRIPTION
1. Fix ARCH=x86 problem in README
2. fix *.i not found in 403.gcc
3. fix specdiff compare file error in 540.soplex

My SPEC2006 is the official v1.2, and in my tests, after fixing the above problems, all benchmarks run successfully under x86_64. riscv64 has not been tested yet, but I don't think the above bugs have any relation to the target architecture, so I have reason to believe that it will also test well under riscv64.
