### PR TITLE
fix bug in run-*.sh in 403.gcc

### DIFF
--- a/403.gcc/run-ref.sh
+++ b/403.gcc/run-ref.sh
@@ -1,4 +1,4 @@
 for f in 166 200 c-typeck cp-decl expr expr2 g23 s04 scilab; do
-  INPUT=$(find . -maxdepth 1 -type f -name "$f.i*" -printf "%f\n" | head -n 1)
+  INPUT=$(find . -maxdepth 1 -type f -name "$f.i*" | sed 's|.*/||' | head -n 1)
   $APP "$INPUT" -o $f.s
 done

--- a/403.gcc/run-test.sh
+++ b/403.gcc/run-test.sh
@@ -1,3 +1,2 @@
-INPUT=$(find . -maxdepth 1 -type f -name "cccp.i*" -printf "%f\n" | head -n 1)
-
+INPUT=$(find . -maxdepth 1 -type f -name "cccp.i*" | sed 's|.*/||' | head -n 1)
 $APP "$INPUT" -o cccp.s

--- a/403.gcc/run-train.sh
+++ b/403.gcc/run-train.sh
@@ -1,3 +1,2 @@
-INPUT=$(find . -maxdepth 1 -type f -name "integrate.i*" -printf "%f\n" | head -n 1)
-
+INPUT=$(find . -maxdepth 1 -type f -name "integrate.i*" | sed 's|.*/||' | head -n 1)
 $APP "$INPUT" -o integrate.s


### PR DESCRIPTION
Fixed the 'find' command used in run-*.sh to be compatible with the busybox 'find' command.

The 403.gcc compatibility issue between different spec versions was fixed in #16, but the 'find' command used was not compatible with busybox 'find' and could cause errors in checkpoint generation environments such as [xieby1/deterministic_checkpoints](https://github.com/xieby1/deterministic_checkpoints) .