### PR TITLE
Deprecate the use of SUBPROCESS_NUM in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,6 @@ SPECFP = 410.bwaves 416.gamess 433.milc 434.zeusmp 435.gromacs 436.cactusADM 437
 ARCH ?= riscv64
 export ARCH
 
-SUBPROCESS_NUM ?= 1
-
 ifeq ($(SPEC_LITE),)
 $(error ERROR: enviroment variable SPEC_LITE is not defined)
 endif
@@ -50,12 +48,12 @@ clean_all_%:
 
 build_int_%:
 	@$(call create_log_dir)
-	@$(MAKE) -s -C $* TESTSET_SPECIFIC_FLAG=-ffp-contract=off -j $(SUBPROCESS_NUM) >> $*/logs/build_fp_$*_$(TIMESTAMP).log 2>&1
+	@$(MAKE) -s -C $* TESTSET_SPECIFIC_FLAG=-ffp-contract=off >> $*/logs/build_fp_$*_$(TIMESTAMP).log 2>&1
 	@echo "Build INT target: $*"
 
 build_fp_%:
 	@$(call create_log_dir)
-	@$(MAKE) -s -C $* -j $(SUBPROCESS_NUM) >> $*/logs/build_fp_$*_$(TIMESTAMP).log 2>&1
+	@$(MAKE) -s -C $* >> $*/logs/build_fp_$*_$(TIMESTAMP).log 2>&1
 	@echo "Build FP target: $*"
 
 collect_%:
@@ -104,7 +102,7 @@ run-int-$(1): $(foreach t,$(SPECINT),run-$t-$(1))
 	$(MAKE) report-int-$(1)
 
 validate-int-$(1):
-	for t in $$(SPECINT); do $$(MAKE) -s -C $$$$t $(1)-cmp; done
+	for t in $$(SPECINT); do $(MAKE) -s -C $$$$t $(1)-cmp; done
 
 run-fp-$(1): $(foreach t,$(SPECFP),run-$t-$(1))
 	echo "\n\n\n"
@@ -116,11 +114,11 @@ run-all-$(1): $(foreach t,$(SPECINT) $(SPECFP),run-$t-$(1))
 	$(MAKE) report-fp-$(1)
 
 validate-fp-$(1):
-	for t in $$(SPECFP); do $$(MAKE) -s -C $$$$t $(1)-cmp; done
+	for t in $$(SPECFP); do $(MAKE) -s -C $$$$t $(1)-cmp; done
 
 run-%-$(1):
 	echo "Running $(1) on $$*"
-	@$$(MAKE) -s -C $$* run-$(1) > $$*/build/run-$(1).log
+	@$(MAKE) -s -C $$* run-$(1) > $$*/build/run-$(1).log
 
 report-int-$(1):
 	for t in $$(SPECINT); do cat $$$$t/run/run-$(1).sh.timelog; echo ""; done

--- a/README.md
+++ b/README.md
@@ -30,13 +30,10 @@ make copy-all-src
 ```
 - compile binarys
 ```
-# '-j 29' means that 29 subitems are constructed at the same time
-# 'SUBPROCESS_NUM' means how many threads are used in the construction of each individual subitem
 make ARCH=riscv64 \
      CROSS_COMPILE=riscv64-unknown-linux-gnu- \
      OPTIMIZE="-O3 -flto" \
-     SUBPROCESS_NUM=5 \
-     build-all -j 29
+     build-all -j `nproc`
 ```
 
 - init data
@@ -53,13 +50,10 @@ make collect-all ELF_PATH=/path/to/elf # ELF_PATH is optional
 
 - compile binarys
 ```
-# '-j 29' means that 29 subitems are constructed at the same time
-# 'SUBPROCESS_NUM' means how many threads are used in the construction of each individual subitem
 make ARCH=riscv64 \
      CROSS_COMPILE=riscv64-unknown-linux-gnu- \
      OPTIMIZE="-O3 -flto -march=rv64gcv_zvl128b_zba_zbb_zbc_zbs -ftree-vectorize  -mabi=lp64d -mrvv-max-lmul=m4 -mrvv-vector-bits=zvl" \
-     SUBPROCESS_NUM=5 \
-     build-all -j 29
+     build-all -j `nproc`
 ```
 
 # With jemalloc
@@ -81,15 +75,12 @@ make && make install
 
 ```shell
 # prepare jemalloc compiled before
-# '-j 29' means that 29 subitems are constructed at the same time
-# 'SUBPROCESS_NUM' means how many threads are used in the construction of each individual subitem
 export RISCV=/riscv_toolchain/top
 export LD_JEMALLOC=1
 make ARCH=riscv64 \
      CROSS_COMPILE=riscv64-unknown-linux-gnu- \
      OPTIMIZE="-O3 -flto" \
-     SUBPROCESS_BUM=5 \
-     build-all -j 29
+     build-all -j `nproc`
 ```
 
 # Run with QEMU to difftest
@@ -112,8 +103,7 @@ export ARCH=riscv64
 make ARCH=riscv64 \
      CROSS_COMPILE=riscv64-unknown-linux-gnu- \
      OPTIMIZE="-O3 -flto" \
-     SUBPROCESS_NUM=5 \
-     build-all -j 29     // compile riscv version
+     build-all -j `nproc`     // compile riscv version
 make run-int-test   // use specint test input, qemu runs about 3mins
 make run-fp-test    // use specfp test input, qemu runs about 15mins
 ```
@@ -126,8 +116,7 @@ you can also compile x86 version and run the x86 compiled binarys native on your
 export ARCH=x86_64
 make ARCH=x86_64 \
      OPTIMIZE="-O3 -flto" \
-     SUBPROCESS_BUM=5 \
-     build-all -j 29     // compile x86 version
+     build-all -j `nproc`     // compile x86 version
 make run-int-test   // use specint test input
 make run-fp-test    // use specfp test input
 ```


### PR DESCRIPTION
Deprecate the use of SUBPROCESS_NUM in Makefile

GNU Make can handle the maximum number of subprocesses correctly by using the objserver feature, it is enabled by default if we call another make process using `$(MAKE)`. So we don't need to set the SUBPROCESS_NUM variable in Makefile. Using `-j` on the top level `make` to control the number of subprocesses more flexible and safer.

Reference:
[1] https://www.gnu.org/software/make/manual/html_node/POSIX-Jobserver.html
[2] https://www.gnu.org/software/make/manual/html_node/MAKE-Variable.html