### PR TITLE
Add logs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build/
 data/
 run/
+logs/
 *.mod
 */src
 bin


### PR DESCRIPTION
We don't want to track logs in git, so we add logs to .gitignore.