### PR TITLE
Makefile: preserve %.fppized.f files when -g is used

### DIFF
--- a/Makefile.apps
+++ b/Makefile.apps
@@ -50,6 +50,10 @@ OBJS := $(patsubst %.cpp,%.o,$(OBJS))
 OBJS := $(patsubst %.cc,%.o,$(OBJS))
 OBJS := $(addprefix $(DST_DIR)/$(TAG), $(OBJS))
 
+ifneq (,$(findstring -g, $(OPTIMIZE)))
+.PRECIOUS: %.fppized.f90 %.fppized.f
+endif
+
 ## 3. General Compilation Flags
 
 -include $(SPEC_LITE)/scripts/$(ARCH).mk


### PR DESCRIPTION
When the -g option is used, these .fppized.f files should not be deleted, as they are referenced in the dwarf debug information to provide the source code in the debugger, objdump, perf report, etc.